### PR TITLE
Replace minitest-reporters with minitest-rg

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "minitest", "~> 5.11"
-gem "minitest-reporters", "~> 1.3"
+gem "minitest-rg", "~> 5.3"
 gem "rake", "~> 13.0"
 gem "rubocop", "1.58.0"
 gem "rubocop-minitest", "0.33.0"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Note that to get the full benefits of the script, you will need the [gh](https:/
 This template is based on `bundle gem` with some notable improvements:
 
 - GitHub Actions configuration
-- Minitest, with minitest-reporters for nicely formatted test output
+- Minitest, with minitest-rg for nicely formatted test output
 - Rubocop with a good set of configuration
 - [release-drafter](https://github.com/apps/release-drafter) GitHub Action for automating release notes
 - A `rake bump` task to keep your Ruby and Bundler dependencies up to date

--- a/test/support/reporters.rb
+++ b/test/support/reporters.rb
@@ -1,7 +1,0 @@
-require "minitest/reporters"
-
-if ENV["CI"]
-  Minitest::Reporters.use!(Minitest::Reporters::SpecReporter.new)
-else
-  Minitest::Reporters.use!(Minitest::Reporters::DefaultReporter.new)
-end

--- a/test/support/rg.rb
+++ b/test/support/rg.rb
@@ -1,0 +1,2 @@
+# Enable color test output
+require "minitest/rg"


### PR DESCRIPTION
Remove `minitest-reporters` in favor of `minitest-rg`, which is simpler, is officially maintained by the minitest GitHub organization, and doesn't patch minitest internals in ways that can break other plugins