### PR TITLE
Drop support for Ruby 3.0 (EOL)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3", "head"]
+        ruby: ["3.1", "3.2", "3.3", "head"]
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
   NewCops: enable
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
   Exclude:
     - "tmp/**/*"
     - "vendor/**/*"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2023 Example Owner
+Copyright (c) 2024 Example Owner
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/example.gemspec
+++ b/example.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.summary = ""
   spec.homepage = "https://github.com/mattbrictson/tomo-plugin"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.0"
+  spec.required_ruby_version = ">= 3.1"
 
   spec.metadata = {
     "bug_tracker_uri" => "https://github.com/mattbrictson/tomo-plugin/issues",

--- a/rename_template.rb
+++ b/rename_template.rb
@@ -177,7 +177,7 @@ end
 
 def ask_yes_or_no(question, default: "N")
   default = default == "Y" ? "Y/n" : "y/N"
-  answer = ask(question, default: default)
+  answer = ask(question, default:)
 
   answer != "y/N" && answer.match?(/^y/i)
 end
@@ -190,7 +190,7 @@ def read_git_data
 
   {
     origin_repo_name: origin_repo_path&.split("/")&.last,
-    origin_repo_path: origin_repo_path,
+    origin_repo_path:,
     user_email: git("config", "user.email").chomp,
     user_name: git("config", "user.name").chomp
   }


### PR DESCRIPTION
- Adopt Ruby 3.1+ implicit hash syntax
